### PR TITLE
Test with Ruby 2.5-3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ rvm:
 env:
   global:
     - CC_TEST_REPORTER_ID=d70fe39ffb8f2f7c5f837f0133d10a3a1c6784d0dd189153111577b60f74c603
+    
+before_install:
+  # https://github.com/rubygems/rubygems/issues/3036
+  # https://github.com/rubygems/rubygems/issues/3036#issuecomment-566132226
+  - yes | gem update --system
+  - gem install bundler
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.5.7
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
 
 env:
   global:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+    simplecov-html (0.12.3)
     ttfunk (1.7.0)
     unicode-display_width (1.6.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    ttfunk (1.6.2.1)
+    ttfunk (1.7.0)
     unicode-display_width (1.6.1)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,4 +84,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.4)
       ast (~> 2.4.0)
-    pdf-core (0.7.0)
+    pdf-core (0.9.0)
     pdf-inspector (1.3.0)
       pdf-reader (>= 1.0, < 3.0.a)
     pdf-reader (2.4.0)
@@ -32,9 +32,9 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    prawn (2.2.2)
-      pdf-core (~> 0.7.0)
-      ttfunk (~> 1.5)
+    prawn (2.4.0)
+      pdf-core (~> 0.9.0)
+      ttfunk (~> 1.7)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
     rainbow (3.0.0)


### PR DESCRIPTION
I'm not sure if this is a welcome change, but since there's no `required_ruby_version` in the `.gemspec` file, I added all versions supported above the one that was being tested. 2.7 and 3.0 contain deprecations so might be worth testing these.