### PR TITLE
Pass tag name and attributes to preprocessor callable

### DIFF
--- a/lib/prawn/markup/processor.rb
+++ b/lib/prawn/markup/processor.rb
@@ -116,7 +116,15 @@ module Prawn
 
       def process_text(text)
         if options[:text] && options[:text][:preprocessor]
-          options[:text][:preprocessor].call(text)
+          if options[:text][:preprocessor].arity == 3
+            options[:text][:preprocessor].call(
+              text,
+              stack.last ? stack.last[:name] : 'div',
+              stack.last ? stack.last[:attrs].symbolize_keys : {}
+            )
+          else
+            options[:text][:preprocessor].call(text)
+          end
         else
           text
         end


### PR DESCRIPTION
The proposed change allows the preprocessor callable to do more than just transform the text contents of tags, like adding anchors to build an outline.
I'd be happy to add documentation to this PR if you think it's a useful change.
The arity check is for backwards compatibility.
This would belong in a minor version bump.