### PR TITLE
Adds support for core Prawn's 'HTML-esque' color tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ doc.markup('<p>Hello World</p><hr/><p>KTHXBYE</p>')
 This gem parses the given HTML and layouts the following elements in a vertical order:
 
 * Text blocks: `p`, `div`, `ol`, `ul`, `li`, `hr`, `br`
-* Text semantics: `a`, `b`, `strong`, `i`, `em`, `u`, `s`, `del`, `sub`, `sup`
+* Text semantics: `a`, `b`, `strong`, `i`, `em`, `u`, `s`, `del`, `sub`, `sup`, `color`
 * Headings: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`
 * Tables: `table`, `tr`, `td`, `th`
 * Media: `img`, `iframe`
 * Inputs: `type=checkbox`, `type=radio`
 
-All other elements are ignored, their content is added to the parent element. With a few exceptions, no CSS is processed. One exception is the `width` property of `img`, `td` and `th`, which may contain values in `cm`, `mm`, `px`, `pt`, `%` or `auto`.
+All other elements are ignored, their content is added to the parent element. With a few exceptions, no CSS is processed. One exception is the `width` property of `img`, `td` and `th`, which may contain values in `cm`, `mm`, `px`, `pt`, `%` or `auto`. Another exception is the `rgb` or `cmyk` properties of the Prawn-specific `color` tag.
 
 If no explicit loader is given (see above), images are loaded from `http(s)` addresses or may be contained in the `src` attribute as base64 encoded data URIs. Prawn only supports `PNG` and `JPG`.
 

--- a/lib/prawn/markup/processor/text.rb
+++ b/lib/prawn/markup/processor/text.rb
@@ -6,7 +6,7 @@ module Prawn
       def self.prepended(base)
         base.known_elements.push(
           'a', 'b', 'strong', 'i', 'em', 'u', 'strikethrough', 'strike', 's', 'del',
-          'sub', 'sup'
+          'sub', 'sup', 'color'
         )
       end
 
@@ -78,6 +78,13 @@ module Prawn
         append_text('</sup>')
       end
 
+      def start_color
+        append_text("<color rgb=\"#{current_attrs['rgb']}\">")
+      end
+
+      def end_color
+        append_text("</color>")
+      end
     end
   end
 end

--- a/lib/prawn/markup/processor/text.rb
+++ b/lib/prawn/markup/processor/text.rb
@@ -79,7 +79,13 @@ module Prawn
       end
 
       def start_color
-        append_text("<color rgb=\"#{current_attrs['rgb']}\">")
+        rgb, c, m, y, k = current_attrs.values_at('rgb', 'c', 'm', 'y', 'k')
+
+        if [c, m, y, k].all?
+          append_text("<color c=\"#{c}\" m=\"#{m}\" y=\"#{y}\" k=\"#{k}\">")
+        else 
+          append_text("<color rgb=\"#{rgb}\">")
+        end
       end
 
       def end_color

--- a/lib/prawn/markup/processor/text.rb
+++ b/lib/prawn/markup/processor/text.rb
@@ -83,13 +83,13 @@ module Prawn
 
         if [c, m, y, k].all?
           append_text("<color c=\"#{c}\" m=\"#{m}\" y=\"#{y}\" k=\"#{k}\">")
-        else 
+        else
           append_text("<color rgb=\"#{rgb}\">")
         end
       end
 
       def end_color
-        append_text("</color>")
+        append_text('</color>')
       end
     end
   end

--- a/spec/prawn/markup/processor/text_spec.rb
+++ b/spec/prawn/markup/processor/text_spec.rb
@@ -20,8 +20,13 @@ RSpec.describe Prawn::Markup::Processor::Text do
     expect(top_positions).to eq([top, top].map(&:round))
   end
 
-  it 'handles prawn tags' do
+  it 'handles prawn color tag for rgb' do
     processor.parse('hello <color rgb="ff0000">world</color>')
+    expect(text.strings).to eq(['hello ', 'world'])
+  end
+
+  it 'handles prawn color tag for cmyk' do
+    processor.parse('hello <color c="22" m="55" y="79" k="30">world</color>')
     expect(text.strings).to eq(['hello ', 'world'])
   end  
 end

--- a/spec/prawn/markup/processor/text_spec.rb
+++ b/spec/prawn/markup/processor/text_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe Prawn::Markup::Processor::Text do
     expect(top_positions).to eq([top, top].map(&:round))
   end
 
+  it 'handles prawn tags' do
+    processor.parse('hello <color rgb="ff0000">world</color>')
+    expect(text.strings).to eq(['hello ', 'world'])
+  end  
 end


### PR DESCRIPTION
Addresses #15 by enabling support for Prawn core's `<color></color>` "HTML-esque" tag.

A few things I'm concerned about here:

1. I'm not sure I put these new methods (`#start_color` `#end_color`) in the _best_ place. Does it make sense to translate non-HTML this way? 
2. Not sure how best to test this either, but I'm looking at ways to improve this...

Thanks!

Here's some manual output to show this actually seems to work...

[test.pdf](https://github.com/puzzle/prawn-markup/files/8173224/test.pdf)