### PR TITLE
Add support for font tag with name attribute

### DIFF
--- a/lib/prawn/markup/processor/text.rb
+++ b/lib/prawn/markup/processor/text.rb
@@ -6,7 +6,7 @@ module Prawn
       def self.prepended(base)
         base.known_elements.push(
           'a', 'b', 'strong', 'i', 'em', 'u', 'strikethrough', 'strike', 's', 'del',
-          'sub', 'sup', 'color'
+          'sub', 'sup', 'color', 'font'
         )
       end
 
@@ -90,6 +90,18 @@ module Prawn
 
       def end_color
         append_text('</color>')
+      end
+
+      def start_font
+        font_attrs = current_attrs
+                     .slice('size', 'name', 'character_spacing')
+                     .reduce('') { |acc, (key, val)| "#{acc} #{key}=\"#{val}\"" }
+
+        append_text("<font #{font_attrs}>")
+      end
+
+      def end_font
+        append_text('</font>')
       end
     end
   end

--- a/spec/prawn/markup/processor/text_spec.rb
+++ b/spec/prawn/markup/processor/text_spec.rb
@@ -29,4 +29,24 @@ RSpec.describe Prawn::Markup::Processor::Text do
     processor.parse('hello <color c="22" m="55" y="79" k="30">world</color>')
     expect(text.strings).to eq(['hello ', 'world'])
   end  
+
+  it 'handles prawn font name' do
+    processor.parse('hello <font name="Courier">world</font>')
+    expect(text.strings).to eq(['hello ', 'world'])
+  end
+
+  it 'handles prawn font size' do
+    processor.parse('hello <font size="20">world</font>')
+    expect(text.strings).to eq(['hello ', 'world'])
+  end
+
+  it 'handles prawn font character_spacing' do
+    processor.parse('hello <font character_spacing="20">world</font>')
+    expect(text.strings).to eq(['hello ', 'world'])
+  end
+
+  it 'handles prawn font multiple attributes' do
+    processor.parse('hello <font name="Courier" size="20">world</font>')
+    expect(text.strings).to eq(['hello ', 'world'])
+  end
 end


### PR DESCRIPTION
Addresses #30 

Adds support for Prawn inline `<font>` tag with three attributes, `name`, `size`, and `character_spacing`.

 