### PR TITLE
Make SAX Parser nokogiri 17 compatible

### DIFF
--- a/lib/prawn/markup/processor.rb
+++ b/lib/prawn/markup/processor.rb
@@ -49,7 +49,9 @@ module Prawn
 
         reset
         html = Prawn::Markup::Normalizer.new(html).normalize
-        Nokogiri::HTML::SAX::Parser.new(self).parse(html) { |ctx| ctx.recovery = true }
+        Nokogiri::HTML::SAX::Parser.new(self, html.encoding&.to_s).parse(html) do |ctx|
+          ctx.recovery = true
+        end
       end
 
       def start_element(name, attrs = [])


### PR DESCRIPTION
Due to changes in nokogiri 17, the SAX parser now needs a default encoding: https://github.com/sparklemotion/nokogiri/pull/3288