### PR TITLE
Fix/headings in tables

### DIFF
--- a/lib/prawn/markup/processor/tables.rb
+++ b/lib/prawn/markup/processor/tables.rb
@@ -87,9 +87,9 @@ module Prawn
         return unless buffered_text?
 
         # only allow on supported options of prawn-table; See https://github.com/prawnpdf/prawn-table/blob/master/manual/table/cell_text.rb
-        options = options.slice(*%i[font font_style inline_format kerning leading min_font_size
-                                    overflow rotate rotate_around single_line size text_color valign])
-        
+        options = options.slice(*%i[font font_style inline_format kerning leading min_font_size size
+                                    overflow rotate rotate_around single_line text_color valign])
+
         cell.nodes << options.merge(content: dump_text.strip)
       end
 

--- a/lib/prawn/markup/processor/tables.rb
+++ b/lib/prawn/markup/processor/tables.rb
@@ -87,8 +87,8 @@ module Prawn
         return unless buffered_text?
 
         # only allow on supported options of prawn-table; See https://github.com/prawnpdf/prawn-table/blob/master/manual/table/cell_text.rb
-        options = options.slice!(*%i[font font_style inline_format kerning leading min_font_size
-                                     overflow rotate rotate_around single_line size text_color valign])
+        options = options.slice(*%i[font font_style inline_format kerning leading min_font_size
+                                    overflow rotate rotate_around single_line size text_color valign])
         
         cell.nodes << options.merge(content: dump_text.strip)
       end

--- a/lib/prawn/markup/processor/tables.rb
+++ b/lib/prawn/markup/processor/tables.rb
@@ -86,6 +86,11 @@ module Prawn
       def add_cell_text_node(cell, options = {})
         return unless buffered_text?
 
+        options[:font_style] ||= options.delete(:style) if options.key?(:style)
+        # only allow on supported options of prawn-table; See https://github.com/prawnpdf/prawn-table/blob/master/manual/table/cell_text.rb
+        options.slice!(*%i[font font_style inline_format kerning leading min_font_size
+                           overflow rotate rotate_around single_line size text_color valign])
+        
         cell.nodes << options.merge(content: dump_text.strip)
       end
 

--- a/lib/prawn/markup/processor/tables.rb
+++ b/lib/prawn/markup/processor/tables.rb
@@ -86,10 +86,9 @@ module Prawn
       def add_cell_text_node(cell, options = {})
         return unless buffered_text?
 
-        options[:font_style] ||= options.delete(:style) if options.key?(:style)
         # only allow on supported options of prawn-table; See https://github.com/prawnpdf/prawn-table/blob/master/manual/table/cell_text.rb
-        options.slice!(*%i[font font_style inline_format kerning leading min_font_size
-                           overflow rotate rotate_around single_line size text_color valign])
+        options = options.slice!(*%i[font font_style inline_format kerning leading min_font_size
+                                     overflow rotate rotate_around single_line size text_color valign])
         
         cell.nodes << options.merge(content: dump_text.strip)
       end

--- a/spec/prawn/markup/processor/tables_spec.rb
+++ b/spec/prawn/markup/processor/tables_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe Prawn::Markup::Processor::Tables do
               first_row_top - 4 * line].map(&:round))
   end
 
+  it 'creates headings inside tables' do
+    processor.parse('<table><tr><td><h1>hello</h1><h2>world</h2></td>></tr></table>')
+    expect(text.strings).to eq(['hello', 'world'])
+    first_sub_col_left = first_col_left + table_padding
+    expect(left_positions).to eq([first_col_left, first_col_left)
+    expect(top_positions).to eq([first_row_top, first_row_top - line].map(&:round))
+  end
+
   it 'creates divs inside tables' do
     processor.parse('<table><tr><td>boot<div>hello<div>world</div><div>and universe</div></div>all the rest</td>' \
                     '<td><div>other</div></td></tr></table>')

--- a/spec/prawn/markup/processor/tables_spec.rb
+++ b/spec/prawn/markup/processor/tables_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe Prawn::Markup::Processor::Tables do
     processor.parse('<table><tr><td>boot<p>hello</p><p>world</p>and universe</td>' \
                     '<td><p>other</p><p><br/></p><p>last</p></td></tr></table>')
     expect(text.strings).to eq(['boot', 'hello', 'world', 'and universe', 'other', 'last'])
-    first_sub_col_left = first_col_left + table_padding
     expect(left_positions)
       .to eq([first_col_left, first_col_left, first_col_left, first_col_left, 342, 342])
     expect(top_positions)
@@ -77,19 +76,26 @@ RSpec.describe Prawn::Markup::Processor::Tables do
               first_row_top - 4 * line].map(&:round))
   end
 
-  it 'creates headings inside tables' do
-    processor.parse('<table><tr><td><h1>hello</h1><h2>world</h2></td>></tr></table>')
-    expect(text.strings).to eq(['hello', 'world'])
-    first_sub_col_left = first_col_left + table_padding
-    expect(left_positions).to eq([first_col_left, first_col_left)
-    expect(top_positions).to eq([first_row_top, first_row_top - line].map(&:round))
+  describe 'nested headings' do
+    let(:options) do
+      {
+        heading1: { size: 36, style: :bold },
+        heading2: { size: 24, style: :bold_italic }
+      }
+    end
+
+    it 'creates headings inside tables' do
+      processor.parse('<table><tr><td><h1>hello</h1><h2>world</h2></td></tr></table>')
+      expect(text.strings).to eq(['hello', 'world'])
+      expect(left_positions).to eq([first_col_left, first_col_left])
+      expect(top_positions).to eq([first_row_top - 17, first_row_top - 50].map(&:round))
+    end
   end
 
   it 'creates divs inside tables' do
     processor.parse('<table><tr><td>boot<div>hello<div>world</div><div>and universe</div></div>all the rest</td>' \
                     '<td><div>other</div></td></tr></table>')
     expect(text.strings).to eq(['boot', 'hello', 'world', 'and universe', 'all the rest', 'other'])
-    first_sub_col_left = first_col_left + table_padding
     expect(left_positions)
       .to eq([first_col_left, first_col_left, first_col_left, first_col_left, first_col_left, 368])
     expect(top_positions)


### PR DESCRIPTION
When the markup contains a table with a nested heading inside, the current behavior will pass on all options of the heading to the cell, which can lead to an error like this:

```rb
undefined method `style=' for an instance of Prawn::Table::Cell::Text
```

Proposal: only pass on known options to prawn-table