### PR TITLE
Add option to treat empty paragraphs as new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Beside these options handled by Prawn / prawn-table, the following values may be
 - `:text`
   - `:preprocessor`: A proc/callable that is called each time before a chunk of text is rendered.
   - `:margin_bottom`: Margin after each `<p>`, `<ol>`, `<ul>` or `<table>`. Defaults to about half a line.
+  - `:treat_empty_paragraph_as_new_line`: Boolean flag to set a new line if paragraph is empty.
 - `:heading1-6`
   - `:margin_top`: Margin before a heading. Default is 0.
   - `:margin_bottom`: Margin after a heading. Default is 0.

--- a/lib/prawn/markup/processor/blocks.rb
+++ b/lib/prawn/markup/processor/blocks.rb
@@ -63,9 +63,14 @@ module Prawn
       def add_paragraph
         text = dump_text
         text.gsub!(/[^\n]/, '') if text.strip.empty?
-        unless text.empty?
+
+        if !text.empty?
           add_bottom_margin
           add_formatted_text(text, text_options)
+          put_bottom_margin(text_margin_bottom)
+        elsif text.empty? && treat_empty_paragraph_as_new_line?
+          add_bottom_margin
+          append_text("\n")
           put_bottom_margin(text_margin_bottom)
         end
       end
@@ -150,6 +155,10 @@ module Prawn
         {
           inline_format: true
         }
+      end
+
+      def treat_empty_paragraph_as_new_line?
+        text_options[:treat_empty_paragraph_as_new_line] || false
       end
     end
   end

--- a/lib/prawn/markup/processor/blocks.rb
+++ b/lib/prawn/markup/processor/blocks.rb
@@ -63,16 +63,11 @@ module Prawn
       def add_paragraph
         text = dump_text
         text.gsub!(/[^\n]/, '') if text.strip.empty?
+        return if text.empty? && !treat_empty_paragraph_as_new_line?
 
-        if !text.empty?
-          add_bottom_margin
-          add_formatted_text(text, text_options)
-          put_bottom_margin(text_margin_bottom)
-        elsif text.empty? && treat_empty_paragraph_as_new_line?
-          add_bottom_margin
-          append_text("\n")
-          put_bottom_margin(text_margin_bottom)
-        end
+        add_bottom_margin
+        add_formatted_text(text.empty? ? "\n" : text, text_options)
+        put_bottom_margin(text_margin_bottom)
       end
 
       def add_current_text(options = text_options)

--- a/spec/prawn/markup/processor/blocks_spec.rb
+++ b/spec/prawn/markup/processor/blocks_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe Prawn::Markup::Processor::Blocks do
           leading: leading,
           size: font_size,
           margin_bottom: 0,
-          preprocessor: ->(text) { text.upcase }
+          preprocessor: ->(text) { text.upcase },
+          treat_empty_paragraph_as_new_line: true
         }
       }
     end
@@ -107,5 +108,10 @@ RSpec.describe Prawn::Markup::Processor::Blocks do
       expect(top_positions).to eq([top, top - line].map(&:round))
     end
 
+    it "treats empty paragraphs as new line if configured" do
+      processor.parse("<p>hello</p><p></p><p>world</p>")
+      expect(text.strings).to eq(%w[HELLO WORLD])
+      expect(top_positions).to eq([top, top - 2 * line].map(&:round))
+    end
   end
 end


### PR DESCRIPTION
 This PR adds option to treat empty paragraphs as line breaks rather than ignoring them. Some rich text editors save html with this in mind, so it's kinda special case.

